### PR TITLE
feat: add Fluent i18n for item and job translations

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -24,6 +24,8 @@ gloo-utils = "0.2.0"
 gloo-console = "0.3"
 gloo-dialogs = "0.2.0"
 gloo-events = "0.2.0"
+fluent-bundle = "0.15"
+unic-langid = "0.9"
 
 [features]
 

--- a/client/src/i18n.rs
+++ b/client/src/i18n.rs
@@ -1,0 +1,176 @@
+use fluent_bundle::{FluentBundle, FluentResource};
+use unic_langid::LanguageIdentifier;
+use web_protocol::{Item, Job};
+
+#[derive(Clone, Copy, PartialEq, Debug, Default)]
+pub enum Lang { #[default] De, En }
+
+// ── Fluent bundles ────────────────────────────────────────────────────────────
+
+thread_local! {
+    static DE_BUNDLE: FluentBundle<FluentResource> =
+        init_bundle("de", include_str!("locales/de.ftl"));
+    static EN_BUNDLE: FluentBundle<FluentResource> =
+        init_bundle("en", include_str!("locales/en.ftl"));
+}
+
+fn init_bundle(lang: &str, source: &'static str) -> FluentBundle<FluentResource> {
+    let langid: LanguageIdentifier = lang.parse().expect("invalid language identifier");
+    let res = FluentResource::try_new(source.to_owned()).expect("FTL parse error");
+    let mut bundle = FluentBundle::new(vec![langid]);
+    bundle.add_resource(res).expect("failed to add FTL resource");
+    bundle
+}
+
+fn ftl_msg(bundle: &FluentBundle<FluentResource>, key: &str) -> String {
+    let msg = bundle
+        .get_message(key)
+        .unwrap_or_else(|| panic!("missing FTL message: {key}"));
+    let val = msg
+        .value()
+        .unwrap_or_else(|| panic!("FTL message has no value: {key}"));
+    let mut errors = vec![];
+    bundle.format_pattern(val, None, &mut errors).into_owned()
+}
+
+fn lookup(lang: Lang, key: &str) -> String {
+    match lang {
+        Lang::De => DE_BUNDLE.with(|b| ftl_msg(b, key)),
+        Lang::En => EN_BUNDLE.with(|b| ftl_msg(b, key)),
+    }
+}
+
+/// Emojis are language-independent; always resolved from the DE bundle.
+fn lookup_emoji(key: &str) -> String {
+    DE_BUNDLE.with(|b| ftl_msg(b, key))
+}
+
+// ── Translate trait ───────────────────────────────────────────────────────────
+
+pub trait Translate: Copy {
+    fn tr_name(self, lang: Lang) -> String;
+    fn tr_desc(self, lang: Lang) -> String;
+    fn tr_emoji(self) -> String;
+    fn tr_tooltip(self, lang: Lang) -> String {
+        format!("{}\n{}", self.tr_name(lang), self.tr_desc(lang))
+    }
+}
+
+// ── Item ─────────────────────────────────────────────────────────────────────
+
+impl Translate for Item {
+    fn tr_name(self, lang: Lang) -> String {
+        lookup(lang, match self {
+            Item::Key                  => "item-key-name",
+            Item::Goblet               => "item-goblet-name",
+            Item::BagKey               => "item-bag-key-name",
+            Item::BagGoblet            => "item-bag-goblet-name",
+            Item::BlackPearl           => "item-black-pearl-name",
+            Item::Dagger               => "item-dagger-name",
+            Item::Gloves               => "item-gloves-name",
+            Item::PoisonRing           => "item-poison-ring-name",
+            Item::CastingKnives        => "item-casting-knives-name",
+            Item::Whip                 => "item-whip-name",
+            Item::Priviledge           => "item-priviledge-name",
+            Item::Monocle              => "item-monocle-name",
+            Item::BrokenMirror         => "item-broken-mirror-name",
+            Item::Sextant              => "item-sextant-name",
+            Item::Coat                 => "item-coat-name",
+            Item::Tome                 => "item-tome-name",
+            Item::CoatOfArmorOfTheLoge => "item-coat-of-armor-name",
+        })
+    }
+
+    fn tr_desc(self, lang: Lang) -> String {
+        lookup(lang, match self {
+            Item::Key                  => "item-key-desc",
+            Item::Goblet               => "item-goblet-desc",
+            Item::BagKey               => "item-bag-key-desc",
+            Item::BagGoblet            => "item-bag-goblet-desc",
+            Item::BlackPearl           => "item-black-pearl-desc",
+            Item::Dagger               => "item-dagger-desc",
+            Item::Gloves               => "item-gloves-desc",
+            Item::PoisonRing           => "item-poison-ring-desc",
+            Item::CastingKnives        => "item-casting-knives-desc",
+            Item::Whip                 => "item-whip-desc",
+            Item::Priviledge           => "item-priviledge-desc",
+            Item::Monocle              => "item-monocle-desc",
+            Item::BrokenMirror         => "item-broken-mirror-desc",
+            Item::Sextant              => "item-sextant-desc",
+            Item::Coat                 => "item-coat-desc",
+            Item::Tome                 => "item-tome-desc",
+            Item::CoatOfArmorOfTheLoge => "item-coat-of-armor-desc",
+        })
+    }
+
+    fn tr_emoji(self) -> String {
+        lookup_emoji(match self {
+            Item::Key                  => "item-key-emoji",
+            Item::Goblet               => "item-goblet-emoji",
+            Item::BagKey               => "item-bag-key-emoji",
+            Item::BagGoblet            => "item-bag-goblet-emoji",
+            Item::BlackPearl           => "item-black-pearl-emoji",
+            Item::Dagger               => "item-dagger-emoji",
+            Item::Gloves               => "item-gloves-emoji",
+            Item::PoisonRing           => "item-poison-ring-emoji",
+            Item::CastingKnives        => "item-casting-knives-emoji",
+            Item::Whip                 => "item-whip-emoji",
+            Item::Priviledge           => "item-priviledge-emoji",
+            Item::Monocle              => "item-monocle-emoji",
+            Item::BrokenMirror         => "item-broken-mirror-emoji",
+            Item::Sextant              => "item-sextant-emoji",
+            Item::Coat                 => "item-coat-emoji",
+            Item::Tome                 => "item-tome-emoji",
+            Item::CoatOfArmorOfTheLoge => "item-coat-of-armor-emoji",
+        })
+    }
+}
+
+// ── Job ──────────────────────────────────────────────────────────────────────
+
+impl Translate for Job {
+    fn tr_name(self, lang: Lang) -> String {
+        lookup(lang, match self {
+            Job::Thug        => "job-thug-name",
+            Job::GrandMaster => "job-grand-master-name",
+            Job::Bodyguard   => "job-bodyguard-name",
+            Job::Duelist     => "job-duelist-name",
+            Job::PoisonMixer => "job-poison-mixer-name",
+            Job::Doctor      => "job-doctor-name",
+            Job::Priest      => "job-priest-name",
+            Job::Hypnotist   => "job-hypnotist-name",
+            Job::Diplomat    => "job-diplomat-name",
+            Job::Clairvoyant => "job-clairvoyant-name",
+        })
+    }
+
+    fn tr_desc(self, lang: Lang) -> String {
+        lookup(lang, match self {
+            Job::Thug        => "job-thug-desc",
+            Job::GrandMaster => "job-grand-master-desc",
+            Job::Bodyguard   => "job-bodyguard-desc",
+            Job::Duelist     => "job-duelist-desc",
+            Job::PoisonMixer => "job-poison-mixer-desc",
+            Job::Doctor      => "job-doctor-desc",
+            Job::Priest      => "job-priest-desc",
+            Job::Hypnotist   => "job-hypnotist-desc",
+            Job::Diplomat    => "job-diplomat-desc",
+            Job::Clairvoyant => "job-clairvoyant-desc",
+        })
+    }
+
+    fn tr_emoji(self) -> String {
+        lookup_emoji(match self {
+            Job::Thug        => "job-thug-emoji",
+            Job::GrandMaster => "job-grand-master-emoji",
+            Job::Bodyguard   => "job-bodyguard-emoji",
+            Job::Duelist     => "job-duelist-emoji",
+            Job::PoisonMixer => "job-poison-mixer-emoji",
+            Job::Doctor      => "job-doctor-emoji",
+            Job::Priest      => "job-priest-emoji",
+            Job::Hypnotist   => "job-hypnotist-emoji",
+            Job::Diplomat    => "job-diplomat-emoji",
+            Job::Clairvoyant => "job-clairvoyant-emoji",
+        })
+    }
+}

--- a/client/src/locales/de.ftl
+++ b/client/src/locales/de.ftl
@@ -1,0 +1,111 @@
+## Items
+
+item-key-name = Schlüssel
+item-key-desc = Der Orden kann den Sieg verkünden, wenn er mindestens 3 Schlüssel besitzt.
+item-key-emoji = 🔑
+
+item-goblet-name = Kelch
+item-goblet-desc = Die Bruderschaft kann den Sieg verkünden, wenn sie mindestens 3 Kelche besitzt.
+item-goblet-emoji = 🏆
+
+item-bag-key-name = Geheimer Koffer (Schlüssel)
+item-bag-key-desc = Tauschst du ihn weiter, darfst du einen Gegenstand vom Stapel ziehen. Darf nicht gegen einen anderen Koffer getauscht werden. Gilt als Schlüssel, wenn der Stapel leer ist.
+item-bag-key-emoji = 🧳
+
+item-bag-goblet-name = Geheimer Koffer (Kelch)
+item-bag-goblet-desc = Tauschst du ihn weiter, darfst du einen Gegenstand vom Stapel ziehen. Darf nicht gegen einen anderen Koffer getauscht werden. Gilt als Kelch, wenn der Stapel leer ist.
+item-bag-goblet-emoji = 🧳
+
+item-black-pearl-name = Schwarze Perle
+item-black-pearl-desc = Muss im Tausch angenommen werden. Wer sie besitzt, darf den Sieg nicht verkünden. (Nur für 4-10 Spieler)
+item-black-pearl-emoji = 🖤
+
+item-dagger-name = Dolch
+item-dagger-desc = Als Angreifer erhältst du +1 auf dein Kampfergebnis. Gilt nicht beim Unterstützen.
+item-dagger-emoji = 🗡️
+
+item-gloves-name = Handschuhe
+item-gloves-desc = Als Verteidiger erhältst du +1 auf dein Kampfergebnis. Gilt nicht beim Unterstützen.
+item-gloves-emoji = 🧤
+
+item-poison-ring-name = Giftring
+item-poison-ring-desc = Als Angreifer oder Verteidiger gewinnst du auch bei einem Patt.
+item-poison-ring-emoji = 💍
+
+item-casting-knives-name = Wurfmesser
+item-casting-knives-desc = Unterstützt du einen Angreifer, erhält dieser +1 auf sein Kampfergebnis.
+item-casting-knives-emoji = 🔪
+
+item-whip-name = Peitsche
+item-whip-desc = Unterstützt du einen Verteidiger, erhält dieser +1 auf sein Kampfergebnis.
+item-whip-emoji = 🪢
+
+item-priviledge-name = Freibrief
+item-priviledge-desc = Tauschst du ihn weiter, darfst du alle Gegenstände deines Tauschpartners ansehen.
+item-priviledge-emoji = 📜
+
+item-monocle-name = Monokel
+item-monocle-desc = Tauschst du es weiter, darfst du die Gesellschaft deines Tauschpartners ansehen.
+item-monocle-emoji = 🧐
+
+item-broken-mirror-name = Zerbrochener Spiegel
+item-broken-mirror-desc = Muss im Tausch angenommen werden. Der erhaltene Gegenstand wirkt sich beim Tausch nicht aus.
+item-broken-mirror-emoji = 🪞
+
+item-sextant-name = Sextant
+item-sextant-desc = Tauschst du ihn weiter, bestimme eine Richtung. Alle geben gleichzeitig einen Gegenstand ihrer Wahl an den Nachbarn in dieser Richtung weiter.
+item-sextant-emoji = 🧭
+
+item-coat-name = Mantel
+item-coat-desc = Tauschst du ihn weiter, wähle einen neuen Beruf aus dem Stapel. Lege deinen alten Beruf zurück. Einmalige Berufe werden zurückgesetzt. (Nur für 3-9 Spieler)
+item-coat-emoji = 🧥
+
+item-tome-name = Foliant
+item-tome-desc = Tauschst du ihn weiter, tauscht du mit deinem Tauschpartner die Berufe. Aufgedeckte Berufe werden wieder verdeckt und können erneut genutzt werden.
+item-tome-emoji = 📖
+
+item-coat-of-armor-name = Wappen der Loge
+item-coat-of-armor-desc = Besitzt du das Wappen und insgesamt 3 Kelche oder Schlüssel in beliebiger Kombination, darfst du deinen alleinigen Sieg verkünden. Karten Trank der Macht zählen nicht.
+item-coat-of-armor-emoji = 🛡️
+
+## Jobs
+
+job-thug-name = Schläger
+job-thug-desc = Als Angreifer erhältst du +1 auf dein Kampfergebnis. Gilt nicht beim Verteidigen oder Unterstützen.
+job-thug-emoji = 💪
+
+job-grand-master-name = Großmeister
+job-grand-master-desc = Als Verteidiger erhältst du +1 auf dein Kampfergebnis. Kann auch nach der Unterstützungsankündigung eingesetzt werden.
+job-grand-master-emoji = ⚜️
+
+job-bodyguard-name = Leibwächter
+job-bodyguard-desc = Unterstützt du jemanden im Kampf, erhält dieser +1 auf sein Kampfergebnis. Gilt nicht für dich selbst.
+job-bodyguard-emoji = 💂
+
+job-duelist-name = Duellant
+job-duelist-desc = Einmalig: Als Angreifer oder Verteidiger kannst du bestimmen, dass niemand unterstützen darf. Du erhältst +1 auf dein Kampfergebnis.
+job-duelist-emoji = 🤺
+
+job-poison-mixer-name = Giftmischer
+job-poison-mixer-desc = Einmalig: Bestimme den Sieger eines Kampfes. Gilt nicht, wenn du Angreifer oder Verteidiger bist.
+job-poison-mixer-emoji = ⚗️
+
+job-doctor-name = Doktor
+job-doctor-desc = Einmalig: Verhindere direkt nach einem Kampf dessen Auswirkungen. Der Sieger erfährt nichts und darf nicht ins Gepäck schauen.
+job-doctor-emoji = 🩺
+
+job-priest-name = Priester
+job-priest-desc = Einmalig: Verhindere vor der Unterstützungsankündigung einen Kampf. Hat der Angreifer mindestens 2 Gegenstände, muss er dir einen abgeben.
+job-priest-emoji = 🙏
+
+job-hypnotist-name = Hypnotiseur
+job-hypnotist-desc = Als Angreifer: Direkt nach der Unterstützungsankündigung kannst du einen Spieler zur Enthaltung zwingen. Er darf keine Gegenstände oder Berufe einsetzen.
+job-hypnotist-emoji = 🌀
+
+job-diplomat-name = Diplomat
+job-diplomat-desc = Einmalig in deinem Zug: Verlange einen bestimmten Gegenstand von einem Mitspieler. Behauptet er, ihn nicht zu haben, muss er alle Gegenstände zeigen.
+job-diplomat-emoji = 🎭
+
+job-clairvoyant-name = Hellseher
+job-clairvoyant-desc = Einmalig: Schaue den Stapel an, wähle 2 Gegenstände, mische den Stapel und lege die gewählten Gegenstände in beliebiger Reihenfolge oben auf.
+job-clairvoyant-emoji = 🔮

--- a/client/src/locales/en.ftl
+++ b/client/src/locales/en.ftl
@@ -1,0 +1,111 @@
+## Items
+
+item-key-name = Key
+item-key-desc = The Order wins if they collectively hold at least 3 Keys.
+item-key-emoji = 🔑
+
+item-goblet-name = Goblet
+item-goblet-desc = The Brotherhood wins if they collectively hold at least 3 Goblets.
+item-goblet-emoji = 🏆
+
+item-bag-key-name = Secret Bag (Key)
+item-bag-key-desc = Trade it: draw one item from the pile. Cannot be traded for the other bag. Becomes a Key when the draw pile is empty.
+item-bag-key-emoji = 🧳
+
+item-bag-goblet-name = Secret Bag (Goblet)
+item-bag-goblet-desc = Trade it: draw one item from the pile. Cannot be traded for the other bag. Becomes a Goblet when the draw pile is empty.
+item-bag-goblet-emoji = 🧳
+
+item-black-pearl-name = Black Pearl
+item-black-pearl-desc = Must always be accepted in a trade. Holder cannot proclaim victory. (4-10 players only)
+item-black-pearl-emoji = 🖤
+
+item-dagger-name = Dagger
+item-dagger-desc = As attacker, +1 to your result. Does not count when supporting.
+item-dagger-emoji = 🗡️
+
+item-gloves-name = Gloves
+item-gloves-desc = As defender, +1 to your result. Does not count when supporting.
+item-gloves-emoji = 🧤
+
+item-poison-ring-name = Poison Ring
+item-poison-ring-desc = As attacker or defender, you win a tie.
+item-poison-ring-emoji = 💍
+
+item-casting-knives-name = Casting Knives
+item-casting-knives-desc = When you support an attacker, they get +1 to their result.
+item-casting-knives-emoji = 🔪
+
+item-whip-name = Whip
+item-whip-desc = When you support a defender, they get +1 to their result.
+item-whip-emoji = 🪢
+
+item-priviledge-name = Privilege
+item-priviledge-desc = Trade it: look at all of your trading partner's items.
+item-priviledge-emoji = 📜
+
+item-monocle-name = Monocle
+item-monocle-desc = Trade it: look at your trading partner's faction card.
+item-monocle-emoji = 🧐
+
+item-broken-mirror-name = Broken Mirror
+item-broken-mirror-desc = Must always be accepted in a trade. The item received in exchange has no trade effect.
+item-broken-mirror-emoji = 🪞
+
+item-sextant-name = Sextant
+item-sextant-desc = Trade it: choose a direction. All players simultaneously pass one item to their neighbor in that direction.
+item-sextant-emoji = 🧭
+
+item-coat-name = Coat
+item-coat-desc = Trade it: pick a new job from the remaining pile. Return your old job. Once-only jobs are reset. (3-9 players only)
+item-coat-emoji = 🧥
+
+item-tome-name = Tome
+item-tome-desc = Trade it: swap jobs with your trading partner. Face-up jobs are turned face-down and may be used again.
+item-tome-emoji = 📖
+
+item-coat-of-armor-name = Coat of Armor of the Loge
+item-coat-of-armor-desc = If you hold this and 3 keys/goblets in any combination, proclaim sole victory - no allies needed. Drink of Power cards do not count.
+item-coat-of-armor-emoji = 🛡️
+
+## Jobs
+
+job-thug-name = Thug
+job-thug-desc = As the attacker in a struggle, you get +1 to your result. Does not count when defending or supporting.
+job-thug-emoji = 💪
+
+job-grand-master-name = Grandmaster
+job-grand-master-desc = As the defender in a struggle, you get +1 to your result. May be used even after support has been declared.
+job-grand-master-emoji = ⚜️
+
+job-bodyguard-name = Bodyguard
+job-bodyguard-desc = When you support someone in a struggle, they get +1 to their result. Does not apply to yourself.
+job-bodyguard-emoji = 💂
+
+job-duelist-name = Duelist
+job-duelist-desc = Once: As attacker or defender, declare that nobody may support this struggle. You get +1 to your result.
+job-duelist-emoji = 🤺
+
+job-poison-mixer-name = Poison Mixer
+job-poison-mixer-desc = Once: Appoint the winner of a struggle. Cannot be used if you are the attacker or defender.
+job-poison-mixer-emoji = ⚗️
+
+job-doctor-name = Doctor
+job-doctor-desc = Once: Immediately after a struggle, prevent all its effects. The winner gains no information and may not search the loser's items.
+job-doctor-emoji = 🩺
+
+job-priest-name = Priest
+job-priest-desc = Once: Before support is declared, stop an attack. If the attacker owns at least 2 items, they must give you one of their choice.
+job-priest-emoji = 🙏
+
+job-hypnotist-name = Hypnotist
+job-hypnotist-desc = As attacker: after support is declared, force one player to abstain. That player may not use items or jobs this struggle.
+job-hypnotist-emoji = 🌀
+
+job-diplomat-name = Diplomat
+job-diplomat-desc = Once, on your turn: demand a specific item from any player. If they deny having it, they must show you all their items.
+job-diplomat-emoji = 🎭
+
+job-clairvoyant-name = Clairvoyant
+job-clairvoyant-desc = Once: Look at the draw pile, pick 2 items, reshuffle, then place them on top in any order.
+job-clairvoyant-emoji = 🔮

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -12,6 +12,7 @@ use yew::prelude::*;
 use yew_router::prelude::*;
 
 use web_protocol::MyState;
+use i18n::Lang;
 
 mod i18n;
 mod ingame;
@@ -31,6 +32,7 @@ type Link = yew_router::prelude::Link<AppRoute>;
 
 struct App {
     my_state: Option<MyState>,
+    lang: Lang,
 }
 
 
@@ -38,6 +40,7 @@ enum Msg {
     GotState(MyState),
     Login,
     Logout,
+    SetLang(Lang),
 }
 
 async fn fetch_json<T: serde::de::DeserializeOwned>(path: &str) -> T {
@@ -95,7 +98,7 @@ impl Component for App {
 
     fn create(ctx: &Context<Self>) -> Self {
         ctx.link().send_future(async { Msg::GotState(fetch_json("/api/me").await) });
-        App { my_state: None }
+        App { my_state: None, lang: Lang::De }
     }
 
     fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> bool {
@@ -111,6 +114,9 @@ impl Component for App {
             Msg::Logout => {
                 window().location().set_pathname("/api/logout").unwrap();
             }
+            Msg::SetLang(l) => {
+                self.lang = l;
+            }
         }
         true
     }
@@ -125,35 +131,52 @@ impl Component for App {
             Some(MyState::LoggedIn { my_games }) => (my_games.clone(), true),
             _ => (vec![], false),
         };
+        let on_lang_change = ctx.link().callback(|e: web_sys::Event| {
+            let select = e.target_unchecked_into::<web_sys::HtmlSelectElement>();
+            match select.value().as_str() {
+                "en" => Msg::SetLang(Lang::En),
+                _    => Msg::SetLang(Lang::De),
+            }
+        });
         html! {
-            <BrowserRouter>
-                <nav class="navbar is-success">
-                    <div class="container">
-                        <div class="navbar-brand">
-                            <div class="navbar-item">
-                                <h3 class="title has-text-white is-4">{"Kutschfahrt"}</h3>
-                            </div>
-                        </div>
-                        <div class="navbar-menu">
-                            <div class="navbar-end">
+            <ContextProvider<Lang> context={self.lang}>
+                <BrowserRouter>
+                    <nav class="navbar is-success">
+                        <div class="container">
+                            <div class="navbar-brand">
                                 <div class="navbar-item">
-                                    {login_btn}
+                                    <h3 class="title has-text-white is-4">{"Kutschfahrt"}</h3>
+                                </div>
+                            </div>
+                            <div class="navbar-menu">
+                                <div class="navbar-end">
+                                    <div class="navbar-item">
+                                        <div class="select is-small">
+                                            <select onchange={on_lang_change}>
+                                                <option value="de" selected={self.lang == Lang::De}>{"🇩🇪 Deutsch"}</option>
+                                                <option value="en" selected={self.lang == Lang::En}>{"🇬🇧 English"}</option>
+                                            </select>
+                                        </div>
+                                    </div>
+                                    <div class="navbar-item">
+                                        {login_btn}
+                                    </div>
                                 </div>
                             </div>
                         </div>
-                    </div>
-                </nav>
+                    </nav>
 
-                <div class="container is-centered">
-                    {if logged_in { html! {
-                        <Switch<AppRoute>
-                            render={move |r| view_content(r, my_games.clone())}
-                        />
-                    } } else { html! {
-                        {"Please log in."}
-                    } }}
-                </div>
-            </BrowserRouter>
+                    <div class="container is-centered">
+                        {if logged_in { html! {
+                            <Switch<AppRoute>
+                                render={move |r| view_content(r, my_games.clone())}
+                            />
+                        } } else { html! {
+                            {"Please log in."}
+                        } }}
+                    </div>
+                </BrowserRouter>
+            </ContextProvider<Lang>>
         }
     }
 }
@@ -162,4 +185,3 @@ fn main() {
     set_panic_hook();
     yew::Renderer::<App>::new().render();
 }
-

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -13,6 +13,7 @@ use yew_router::prelude::*;
 
 use web_protocol::MyState;
 
+mod i18n;
 mod ingame;
 
 


### PR DESCRIPTION
## Summary

- Introduces Mozilla Fluent as the localization backend for item and job names, descriptions, and emojis
- All strings live in two FTL files instead of hardcoded Rust match arms
- Add `fluent-bundle` + `unic-langid` to `client/Cargo.toml`
- Create `client/src/locales/de.ftl` and `en.ftl` with all 17 items and 10 jobs (name, desc, emoji)
- `Translate` trait: `tr_name`, `tr_desc`, `tr_emoji` return `String`, backed by `thread_local!` Fluent bundles
- Emojis are language-independent, resolved from the DE bundle

## Test plan

- [x] `cargo check` passes cleanly
- [x] Single commit based directly on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)